### PR TITLE
Fixed typographical error, changed arbitarily to arbitrarily in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ end
 ### JSON Objects
 
 The `put` method is used to serialize named object values and
-create arbitarily nested objects.
+create arbitrarily nested objects.
 
 All values will be serialized according to Oj processing rules.
 


### PR DESCRIPTION
@ahacking, I've corrected a typographical error in the documentation of the [to_json](https://github.com/ahacking/to_json) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
